### PR TITLE
feat: Add Receipt Page from ecommerce to MFE

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,6 +17,7 @@ SITE_NAME=localhost
 MARKETING_SITE_BASE_URL=http://localhost:18000
 SUPPORT_URL=http://localhost:18000/support
 ORDER_HISTORY_URL=http://localhost:1996/orders
+RECEIPT_URL=http://localhost:1996/receipt
 LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
 LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
 LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg

--- a/.env.test
+++ b/.env.test
@@ -17,6 +17,7 @@ SITE_NAME=localhost
 MARKETING_SITE_BASE_URL=http://localhost:18000
 SUPPORT_URL=http://localhost:18000/support
 ORDER_HISTORY_URL=https://localhost:1996/orders
+RECEIPT_URL=http://localhost:1996/receipt
 LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
 LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
 LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "prop-types": "15.8.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
+        "react-helmet": "^6.1.0",
         "react-redux": "^7.2.8",
         "react-responsive": "8.2.0",
         "react-router": "^4.3.1",
@@ -22411,6 +22412,20 @@
         }
       }
     },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-intl": {
       "version": "5.25.1",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.25.1.tgz",
@@ -22700,6 +22715,14 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-style-singleton": {
@@ -43814,6 +43837,17 @@
         "use-sidecar": "^1.0.5"
       }
     },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      }
+    },
     "react-intl": {
       "version": "5.25.1",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.25.1.tgz",
@@ -44050,6 +44084,12 @@
           }
         }
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "requires": {}
     },
     "react-style-singleton": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "prop-types": "15.8.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
+    "react-helmet": "^6.1.0",
     "react-redux": "^7.2.8",
     "react-responsive": "8.2.0",
     "react-router": "^4.3.1",

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-us">
   <head>
-      <title>Order History | edX</title>
+      <title><%= process.env.SITE_NAME %> | edX</title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />

--- a/src/components/NotFoundPage.jsx
+++ b/src/components/NotFoundPage.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import PropTypes from 'prop-types';
 
-export default function NotFoundPage() {
+export default function NotFoundPage(props) {
+  const { error } = props;
   return (
     <div className="container-fluid d-flex py-5 justify-content-center align-items-start text-center">
       <p className="my-0 py-5 text-muted" style={{ maxWidth: '32em' }}>
@@ -10,7 +12,16 @@ export default function NotFoundPage() {
           defaultMessage="The page you're looking for is unavailable or there's an error in the URL. Please check the URL and try again."
           description="error message when a page does not exist"
         />
+        <span>{error}</span>
       </p>
     </div>
   );
 }
+
+NotFoundPage.defaultProps = {
+  error: null,
+};
+
+NotFoundPage.propTypes = {
+  error: PropTypes.string,
+};

--- a/src/components/NotFoundPage.jsx
+++ b/src/components/NotFoundPage.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 
-export default function NotFoundPage(props) {
-  const { error } = props;
+export default function NotFoundPage({ error }) {
   return (
     <div className="container-fluid d-flex py-5 justify-content-center align-items-start text-center">
       <p className="my-0 py-5 text-muted" style={{ maxWidth: '32em' }}>
@@ -12,7 +11,7 @@ export default function NotFoundPage(props) {
           defaultMessage="The page you're looking for is unavailable or there's an error in the URL. Please check the URL and try again."
           description="error message when a page does not exist"
         />
-        <span>{error}</span>
+        { error ? <span>{error}</span> : null }
       </p>
     </div>
   );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,6 +18,7 @@ import messages from './i18n';
 import configureStore from './store';
 import NotFoundPage from './components/NotFoundPage';
 import { ConnectedOrderHistoryPage } from './order-history';
+import { ConnectedReceiptPage } from './receipt';
 
 import './index.scss';
 
@@ -28,6 +29,7 @@ subscribe(APP_READY, () => {
       <main>
         <Switch>
           <Route path="/orders" component={ConnectedOrderHistoryPage} />
+          <Route path="/receipt" component={ConnectedReceiptPage} />
           <Route path="/notfound" component={NotFoundPage} />
           <Route path="*" component={NotFoundPage} />
         </Switch>

--- a/src/index.scss
+++ b/src/index.scss
@@ -11,6 +11,7 @@ $fa-font-path: "~font-awesome/fonts";
 @import "~@edx/frontend-component-footer/dist/footer";
 
 @import "./order-history/style";
+@import "./receipt/style";
 
 .word-break-all {
   word-break: break-all !important;

--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -10,7 +10,7 @@ import {
   FormattedDate,
   FormattedNumber,
 } from '@edx/frontend-platform/i18n';
-import { Table, Hyperlink, Pagination } from '@edx/paragon';
+import { DataTable, Hyperlink, Pagination } from '@edx/paragon';
 import MediaQuery from 'react-responsive';
 
 import messages from './OrderHistoryPage.messages';
@@ -91,32 +91,34 @@ class OrderHistoryPage extends React.Component {
 
   renderOrdersTable() {
     return (
-      <Table
+      <DataTable
         className="order-history table-bordered"
+        itemCount={this.props.orders.length}
         data={this.getTableData()}
         columns={[
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.items']),
-            key: 'description',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.items']),
+            accessor: 'description',
           },
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.date.placed']),
-            key: 'datePlaced',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.date.placed']),
+            accessor: 'datePlaced',
           },
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.total.cost']),
-            key: 'total',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.total.cost']),
+            accessor: 'total',
           },
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.number']),
-            key: 'orderId',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.number']),
+            accessor: 'orderId',
           },
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.details']),
-            key: 'receiptUrl',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.details']),
+            accessor: 'receiptUrl',
           },
         ]}
-      />
+      ><DataTable.Table />
+      </DataTable>
     );
   }
 

--- a/src/receipt/ReceiptPage.jsx
+++ b/src/receipt/ReceiptPage.jsx
@@ -12,7 +12,7 @@ import {
   FormattedNumber,
 } from '@edx/frontend-platform/i18n';
 import {
-  ActionRow, Alert, Badge, DataTable, Hyperlink, PageBanner,
+  ActionRow, Alert, Badge, DataTable, Hyperlink, MailtoLink, PageBanner,
 } from '@edx/paragon';
 import { Info } from '@edx/paragon/icons';
 
@@ -46,7 +46,7 @@ class ReceiptPage extends React.Component {
       product.is_enrollment_code_product ? (
         <span key={product.id}>
           {this.props.intl.formatMessage(messages['ecommerce.receipt.confirm.message.enrollment.code'])}
-          <Hyperlink data-hj-suppress destination="mailto:{order.user.email}">{this.props.order.user.email}</Hyperlink>
+          <MailtoLink data-hj-suppress to={this.props.order.user.email}>{this.props.order.user.email}</MailtoLink>
         </span>
       ) : (
         <span key={product.id}>

--- a/src/receipt/ReceiptPage.jsx
+++ b/src/receipt/ReceiptPage.jsx
@@ -130,12 +130,12 @@ class ReceiptPage extends React.Component {
 
   renderCreditMessaging() {
     const dashboardLink = (
-      <a className="inline-link-underline" rel="noopener noreferrer" target="_blank" href={DASHBOARD_URL}>
+      <Hyperlink className="inline-link-underline" destination={DASHBOARD_URL}>
         <FormattedMessage
           id="ecommerce.receipt.credit.messaging.message.link"
           defaultMessage="dashboard"
         />
-      </a>
+      </Hyperlink>
     );
     return (
       <Alert
@@ -162,12 +162,12 @@ class ReceiptPage extends React.Component {
 
   renderEnterpriseMessage() {
     const learnerPortalLink = (
-      <a className="inline-link-underline" rel="noopener noreferrer" target="_blank" href={this.props.order.enterprise_learner_portal_url}>
+      <Hyperlink className="inline-link-underline" destination={this.props.order.enterprise_learner_portal_url}>
         <FormattedMessage
           id="ecommerce.receipt.page.banner.enterprise.message.link"
           defaultMessage="your learner portal"
         />
-      </a>
+      </Hyperlink>
     );
 
     // eslint-disable-next-line no-unused-expressions
@@ -194,12 +194,12 @@ class ReceiptPage extends React.Component {
   renderError() {
     const { ORDER_HISTORY_URL } = getConfig();
     const orderHistoryLink = (
-      <a className="inline-link-underline" rel="noopener noreferrer" target="_blank" href={ORDER_HISTORY_URL}>
+      <Hyperlink className="inline-link-underline" destination={ORDER_HISTORY_URL}>
         <FormattedMessage
           id="ecommerce.receipt.loading.error.link"
           defaultMessage="order history"
         />
-      </a>
+      </Hyperlink>
     );
     return (
       <div id="receipt-container" className="page__receipt receipt container content-container pt-5 pb-5">

--- a/src/receipt/ReceiptPage.jsx
+++ b/src/receipt/ReceiptPage.jsx
@@ -234,7 +234,7 @@ class ReceiptPage extends React.Component {
     return this.props.order.lines.map(line => (
       <DataTable
         aria-hidden="true"
-        itemCount={this.props.order.lines.length}
+        itemCount="1"
         data={[
           {
             quantity: line.quantity,

--- a/src/receipt/ReceiptPage.jsx
+++ b/src/receipt/ReceiptPage.jsx
@@ -303,7 +303,7 @@ class ReceiptPage extends React.Component {
                   <div className="confirm-message">
                     {this.getConfirmMessage()}
                   </div>
-                  {order.billing_address ? (
+                  {order.billing_address && (
                     <address className="billing-address" data-hj-suppress>
                       {order.billing_address.first_name} {order.billing_address.last_name}<br />
                       {order.billing_address.line1}<br />
@@ -312,18 +312,18 @@ class ReceiptPage extends React.Component {
                       {order.billing_address.postcode}<br />
                       {order.billing_address.country}<br />
                     </address>
-                  ) : null}
+                  )}
                 </div>
                 <div className="order-summary col-md-4">
                   <dl>
                     <dt>{this.props.intl.formatMessage(messages['ecommerce.receipt.order.summary.order.number'])}</dt>
                     <dd>{order.number}</dd>
-                    {order.payment_method ? (
+                    {order.payment_method && (
                       <>
                         <dt>{this.props.intl.formatMessage(messages['ecommerce.receipt.order.summary.payment.method'])}</dt>
                         <dd>{order.payment_method}</dd>
                       </>
-                    ) : null}
+                    )}
                     <dt>{this.props.intl.formatMessage(messages['ecommerce.receipt.order.summary.order.date'])}</dt>
                     <dd>{new Date(order.date_placed).toLocaleDateString('default', { month: 'short', day: 'numeric', year: 'numeric' })}</dd>
                   </dl>
@@ -342,14 +342,14 @@ class ReceiptPage extends React.Component {
                       currency={this.props.order.currency}
                     />
                   </ActionRow>
-                  {order.vouchers ? (
+                  {order.vouchers && (
                     <>
                       <ActionRow className="order-total-item">
                         <Badge variant="success">{this.props.intl.formatMessage(messages['ecommerce.receipt.table.order.discount'])}</Badge>
                         <ActionRow.Spacer />
                         {this.renderDiscountByType(order.basket_discounts)}
                       </ActionRow>
-                      {order.enterprise_learner_portal_url ? (
+                      {order.enterprise_learner_portal_url && (
                         <div className="enterprise-customer">
                           <FormattedMessage
                             id="ecommerce.receipt.table.order.discount.message.enterprise.secondary"
@@ -359,11 +359,10 @@ class ReceiptPage extends React.Component {
                             }}
                           />
                         </div>
-                      ) : null}
+                      )}
                       <ActionRow className="border-divider" />
                     </>
-                  )
-                    : null}
+                  )}
                   <ActionRow className="order-total-item">
                     <span>{this.props.intl.formatMessage(messages['ecommerce.receipt.table.order.total'])}</span>
                     <ActionRow.Spacer />
@@ -375,7 +374,7 @@ class ReceiptPage extends React.Component {
                   </ActionRow>
                 </div>
               </div>
-              {order.contains_credit_seat ? this.renderCreditMessaging() : null}
+              {order.contains_credit_seat && this.renderCreditMessaging()}
               <ActionRow id="cta-nav-links">
                 <Hyperlink className="dashboard-link" destination={DASHBOARD_URL}>{this.props.intl.formatMessage(messages['ecommerce.receipt.link.dashboard'])}</Hyperlink>
                 <Hyperlink destination={FIND_COURSES_URL}>{this.props.intl.formatMessage(messages['ecommerce.receipt.link.find.courses'])}</Hyperlink>

--- a/src/receipt/ReceiptPage.jsx
+++ b/src/receipt/ReceiptPage.jsx
@@ -1,0 +1,407 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import {
+  getConfig,
+} from '@edx/frontend-platform';
+import {
+  injectIntl,
+  intlShape,
+  FormattedMessage,
+  FormattedNumber,
+} from '@edx/frontend-platform/i18n';
+import {
+  ActionRow, Alert, Badge, DataTable, Hyperlink,
+} from '@edx/paragon';
+import { Info } from '@edx/paragon/icons';
+
+import messages from './ReceiptPage.messages';
+
+// Actions
+import { fetchOrder } from './actions';
+import { receiptSelector } from './selectors';
+import { PageLoading } from '../common';
+
+const { LMS_BASE_URL } = getConfig();
+const DASHBOARD_URL = `${LMS_BASE_URL}/dashboard`;
+const FIND_COURSES_URL = `${LMS_BASE_URL}/courses`;
+class ReceiptPage extends React.Component {
+  componentDidMount() {
+    const orderNumber = this.props.history.location.search.split('=')[1];
+    this.props.fetchOrder(orderNumber);
+  }
+
+  getConfirmMessage() {
+    return this.props.order.lines.map(({
+      product,
+    }) => (
+      product.is_enrollment_code_product ? (
+        <span key={product.id}>
+          {this.props.intl.formatMessage(messages['ecommerce.receipt.confirm.message.enrollment.code'])}
+          <Hyperlink data-hj-suppress destination="mailto:{order.user.email}">{this.props.order.user.email}</Hyperlink>
+        </span>
+      ) : (
+        <span key={product.id}>
+          {this.props.intl.formatMessage(messages['ecommerce.receipt.confirm.message'])}
+        </span>
+      )
+    ));
+  }
+
+  renderDiscountByType(discounts) {
+    return discounts.map(discount => {
+      const discountAmount = (
+        <FormattedNumber
+          value={-Math.abs(discount.amount)}
+          style="currency" // eslint-disable-line react/style-prop-object
+          currency={discount.currency}
+        />
+      );
+      if (discount.code) {
+        return (
+          <>
+            <span data-hj-suppress>{discount.code}</span>
+            <ActionRow.Spacer />
+            <span>{discount.benefit_value}% off</span>
+            <ActionRow.Spacer />
+            <span>{discountAmount}</span>
+          </>
+        );
+      }
+      if (discount.contains_offer) {
+        if (discount.enterprise_customer_name) {
+          return (
+            <>
+              <FormattedMessage
+                id="ecommerce.receipt.table.order.discount.message.enterprise"
+                defaultMessage="Discount of type {offerType} provided by {enterpriseCustomer}"
+                key={discount.id}
+                values={{
+                  offerType: discount.offer_type,
+                  enterpriseCustomer: discount.enterprise_customer_name,
+                }}
+              />
+              <ActionRow.Spacer />
+              <span>{discountAmount}</span>
+            </>
+          );
+        // eslint-disable-next-line no-else-return
+        } else if (discount.condition_name === 'dynamic_discount_condition') {
+          return (
+            <>
+              <span key={discount.id}>{this.props.intl.formatMessage(messages['ecommerce.receipt.table.order.discount.message.fpd'])}</span>
+              <ActionRow.Spacer />
+              <span>{discountAmount}</span>
+            </>
+          );
+        } else {
+          return (
+            <>
+              <FormattedMessage
+                id="ecommerce.receipt.table.order.discount.message"
+                defaultMessage="Discount of type {offerType} is provided"
+                key={discount.id}
+                values={{
+                  offerType: discount.offer_type,
+                }}
+              />
+              <ActionRow.Spacer />
+              <span>{discountAmount}</span>
+            </>
+          );
+        }
+      }
+      return <span>{discountAmount}</span>;
+    });
+  }
+
+  renderCreditMessaging() {
+    const dashboardLink = (
+      <a className="inline-link-underline" rel="noopener noreferrer" target="_blank" href={DASHBOARD_URL}>
+        <FormattedMessage
+          id="ecommerce.receipt.credit.messaging.message.link"
+          defaultMessage="dashboard"
+        />
+      </a>
+    );
+    return this.props.order.lines.map(({
+      product,
+    }) => (
+      <>
+        {product.is_enrollment_code_product ? (
+          <Alert
+            variant="warning"
+            icon={Info}
+            className="credit-messaging"
+            key={product.id}
+          >
+            <Alert.Heading>
+              <FormattedMessage
+                id="ecommerce.receipt.credit.messaging.header"
+                defaultMessage="Get Your Course Credit"
+              />
+            </Alert.Heading>
+            <p>
+              <FormattedMessage
+                id="ecommerce.receipt.credit.messaging.message"
+                defaultMessage="To receive academic credit for this course, you must apply for credit at the organization that offers the credit. You can find a link to the organization’s website on your {dashboardLink}, next to the course name."
+                values={{ dashboardLink }}
+              />
+            </p>
+          </Alert>
+        ) : null}
+      </>
+    ));
+  }
+
+  renderError() {
+    const { ORDER_HISTORY_URL } = getConfig();
+    const orderHistoryLink = (
+      <a className="inline-link-underline" rel="noopener noreferrer" target="_blank" href={ORDER_HISTORY_URL}>
+        <FormattedMessage
+          id="ecommerce.receipt.loading.error.link"
+          defaultMessage="order history"
+        />
+      </a>
+    );
+    return (
+      <div id="receipt-container" className="page__receipt receipt container content-container pt-5 pb-5">
+        <span>
+          <FormattedMessage
+            id="ecommerce.receipt.loading.error"
+            defaultMessage="The specified order could not be located. Please ensure that the URL is correct, and try again. You may also view your previous orders on the {orderHistoryLink} page."
+            values={{ orderHistoryLink }}
+          />
+        </span>
+      </div>
+    );
+  }
+
+  renderLoading() {
+    return (
+      <PageLoading srMessage={this.props.intl.formatMessage(messages['ecommerce.receipt.loading.order'])} />
+    );
+  }
+
+  renderOrderTable() {
+    // TODO: can we add data-couse-id, className, key to rendered child elements from Paragon
+    return this.props.order.lines.map(line => (
+      <DataTable
+        aria-hidden="true"
+        itemCount={this.props.order.lines.length}
+        data={[
+          {
+            quantity: line.quantity,
+            description: line.description,
+            item_price: <FormattedNumber
+              value={this.props.order.total_before_discounts_incl_tax}
+              style="currency" // eslint-disable-line react/style-prop-object
+              currency={this.props.order.currency}
+            />,
+          },
+        ]}
+        columns={[
+          {
+            Header: this.props.intl.formatMessage(messages['ecommerce.receipt.table.column.quantity']),
+            accessor: 'quantity',
+          },
+          {
+            Header: this.props.intl.formatMessage(messages['ecommerce.receipt.table.column.description']),
+            accessor: 'description',
+          },
+          {
+            Header: this.props.intl.formatMessage(messages['ecommerce.receipt.table.column.price']),
+            accessor: 'item_price',
+          },
+        ]}
+      >
+        <DataTable.Table />
+      </DataTable>
+    ));
+  }
+
+  render() {
+    const {
+      loadingReceipt,
+      loadingReceiptError,
+      order,
+    } = this.props;
+    const loaded = !loadingReceipt && !loadingReceiptError;
+
+    return (
+      <>
+        {loadingReceiptError ? this.renderError() : null}
+        {loadingReceipt ? this.renderLoading() : null}
+        {loaded && order ? (
+          <div
+            id="receipt-container"
+            className="page__receipt receipt container content-container"
+            data-currency={order.currency}
+            data-order-id={order.number}
+            data-total-amount={order.total_before_discounts_incl_tax}
+            data-product-ids={order.order_product_ids}
+            // data-back-button="{{ disable_back_button | default:0 }}"
+          >
+            <div className="list-info">
+              <h2 className="thank-you text-primary-500">{this.props.intl.formatMessage(messages['ecommerce.receipt.heading'])}</h2>
+              <div className="info-item payment-info row">
+                <div className="copy col-md-8">
+                  <div className="confirm-message">
+                    {this.getConfirmMessage()}
+                  </div>
+                  {order.billing_address ? (
+                    <address className="billing-address" data-hj-suppress>
+                      {order.billing_address.first_name} {order.billing_address.last_name} <br />
+                      {order.billing_address.line1} <br />
+                      {order.billing_address.city} <br />
+                      {order.billing_address.state} <br />
+                      {order.billing_address.postcode} <br />
+                      {order.billing_address.country} <br />
+                    </address>
+                  ) : null}
+                </div>
+                <div className="order-summary col-md-4">
+                  <dl>
+                    <dt>{this.props.intl.formatMessage(messages['ecommerce.receipt.order.summary.order.number'])}</dt>
+                    <dd>{order.number}</dd>
+                    {order.payment_method ? (
+                      <>
+                        <dt>{this.props.intl.formatMessage(messages['ecommerce.receipt.order.summary.payment.method'])}</dt>
+                        <dd>{order.payment_method}</dd>
+                      </>
+                    ) : null}
+                    <dt>{this.props.intl.formatMessage(messages['ecommerce.receipt.order.summary.order.date'])}</dt>
+                    <dd>{new Date(order.date_placed).toLocaleDateString('default', { month: 'short', day: 'numeric', year: 'numeric' })}</dd>
+                  </dl>
+                </div>
+              </div>
+              <h2 className="text-primary-500">{this.props.intl.formatMessage(messages['ecommerce.receipt.table.order.information'])}</h2>
+              <div className="info-table">{this.renderOrderTable()}</div>
+              <div className="row">
+                <div className="order-total col-6 ml-auto">
+                  <ActionRow className="order-total-item border-divider">
+                    <span className="description">{this.props.intl.formatMessage(messages['ecommerce.receipt.table.order.subtotal'])}</span>
+                    <ActionRow.Spacer />
+                    <FormattedNumber
+                      value={this.props.order.total_before_discounts_incl_tax}
+                      style="currency" // eslint-disable-line react/style-prop-object
+                      currency={this.props.order.currency}
+                    />
+                  </ActionRow>
+                  {order.vouchers ? (
+                    <>
+                      <ActionRow className="order-total-item">
+                        <Badge variant="success">{this.props.intl.formatMessage(messages['ecommerce.receipt.table.order.discount'])}</Badge>
+                        <ActionRow.Spacer />
+                        {this.renderDiscountByType(order.basket_discounts)}
+                      </ActionRow>
+                      {order.enterprise_customer_info ? (
+                        <div className="enterprise-customer">
+                          <FormattedMessage
+                            id="ecommerce.receipt.table.order.discount.message.enterprise.secondary"
+                            defaultMessage="Courtesy of {enterpriseName} is provided"
+                            values={{
+                              enterpriseName: order.enterprise_customer_info.offer_condition_enterprise_customer_name,
+                            }}
+                          />
+                        </div>
+                      ) : null}
+                      <ActionRow className="border-divider" />
+                    </>
+                  )
+                    : null}
+                  <ActionRow className="order-total-item">
+                    <span>{this.props.intl.formatMessage(messages['ecommerce.receipt.table.order.total'])}</span>
+                    <ActionRow.Spacer />
+                    <FormattedNumber
+                      value={this.props.order.total_excl_tax}
+                      style="currency" // eslint-disable-line react/style-prop-object
+                      currency={this.props.order.currency}
+                    />
+                  </ActionRow>
+                </div>
+              </div>
+              {this.renderCreditMessaging()}
+              <ActionRow id="cta-nav-links">
+                <Hyperlink className="dashboard-link" destination={DASHBOARD_URL}>{this.props.intl.formatMessage(messages['ecommerce.receipt.link.dashboard'])}</Hyperlink>
+                <Hyperlink destination={FIND_COURSES_URL}> {this.props.intl.formatMessage(messages['ecommerce.receipt.link.find.courses'])}</Hyperlink>
+              </ActionRow>
+            </div>
+          </div>
+        ) : null}
+      </>
+    );
+  }
+}
+
+ReceiptPage.propTypes = {
+  intl: intlShape.isRequired,
+  history: PropTypes.shape({
+    location: PropTypes.shape({
+      search: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  order: PropTypes.shape({
+    basket_discounts: PropTypes.arrayOf(PropTypes.shape({
+      amount: PropTypes.number,
+      benefit: PropTypes.number,
+      code: PropTypes.string,
+      condition_name: PropTypes.string,
+      contains_offer: PropTypes.bool,
+      currency: PropTypes.string,
+      enterprise_customer_name: PropTypes.string,
+      offer_type: PropTypes.string,
+    })),
+    billing_address: PropTypes.shape({
+      city: PropTypes.string,
+      country: PropTypes.string,
+      first_name: PropTypes.string,
+      last_name: PropTypes.string,
+      line1: PropTypes.string,
+      line2: PropTypes.string,
+      postcode: PropTypes.string,
+      state: PropTypes.string,
+    }),
+    currency: PropTypes.string,
+    date_placed: PropTypes.string,
+    discount: PropTypes.string,
+    enterprise_learner_portal_url: PropTypes.string,
+    lines: PropTypes.arrayOf(PropTypes.shape({
+      description: PropTypes.string,
+      linePriceExclTax: PropTypes.string,
+      quantity: PropTypes.number,
+      unitPriceExclTax: PropTypes.string,
+    })),
+    number: PropTypes.string,
+    order_product_ids: PropTypes.string,
+    payment_method: PropTypes.string,
+    product_tracking: PropTypes.string,
+    total_before_discounts_incl_tax: PropTypes.string,
+    total_excl_tax: PropTypes.string,
+    user: PropTypes.shape({
+      email: PropTypes.string,
+      username: PropTypes.string,
+    }),
+    vouchers: PropTypes.arrayOf(PropTypes.shape({
+      benefit: PropTypes.shape({
+        type: PropTypes.string,
+        value: PropTypes.number,
+      }),
+      code: PropTypes.string,
+      total_discount: PropTypes.string,
+    })),
+  }),
+  loadingReceipt: PropTypes.bool,
+  loadingReceiptError: PropTypes.string,
+  fetchOrder: PropTypes.func.isRequired,
+};
+
+ReceiptPage.defaultProps = {
+  order: null,
+  loadingReceiptError: null,
+  loadingReceipt: false,
+};
+
+export default connect(receiptSelector, {
+  fetchOrder,
+})(injectIntl(ReceiptPage));

--- a/src/receipt/ReceiptPage.messages.jsx
+++ b/src/receipt/ReceiptPage.messages.jsx
@@ -1,0 +1,91 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  'ecommerce.receipt.heading': {
+    id: 'ecommerce.receipt.heading',
+    defaultMessage: 'Thank you for your order!',
+    description: 'Page heading for receipt.',
+  },
+  'ecommerce.receipt.confirm.message': {
+    id: 'ecommerce.receipt.confirm.message',
+    defaultMessage: 'Your order is complete. If you need a receipt, you can print this page.',
+    description: 'Receipt order confirmation message',
+  },
+  'ecommerce.receipt.confirm.message.enrollment.code': {
+    id: 'ecommerce.receipt.confirm.message.enrollment.code',
+    defaultMessage: 'Your order is complete. If you need a receipt, you can print this page.You will also receive a confirmation message with this information at ',
+    description: 'Receipt order confirmation message for enrollment code product',
+  },
+  'ecommerce.receipt.table.order.information': {
+    id: 'ecommerce.receipt.table.order.information',
+    defaultMessage: 'Order Information',
+    description: 'Order information heading for order table',
+  },
+  'ecommerce.receipt.table.order.discount': {
+    id: 'ecommerce.receipt.table.order.discount',
+    defaultMessage: 'Discount',
+    description: 'Order table title for order discount',
+  },
+  'ecommerce.receipt.table.order.discount.message.fpd': {
+    id: 'ecommerce.receipt.table.order.discount.message.fpd',
+    defaultMessage: 'Discount for your first upgrade',
+    description: 'Message on discount section for first purchase discount',
+  },
+  'ecommerce.receipt.table.order.subtotal': {
+    id: 'ecommerce.receipt.table.order.subtotal',
+    defaultMessage: 'Subtotal',
+    description: 'Order table title for order subtotal',
+  },
+  'ecommerce.receipt.table.order.total': {
+    id: 'ecommerce.receipt.table.order.total',
+    defaultMessage: 'Total',
+    description: 'Order table title for order total',
+  },
+  'ecommerce.receipt.order.summary.order.date': {
+    id: 'ecommerce.receipt.order.summary.order.date',
+    defaultMessage: 'Order Date:',
+    description: 'Order summary heading for order date',
+  },
+  'ecommerce.receipt.order.summary.order.number': {
+    id: 'ecommerce.receipt.order.summary.order.number',
+    defaultMessage: 'Order Number:',
+    description: 'Order summary heading for order number',
+  },
+  'ecommerce.receipt.order.summary.payment.method': {
+    id: 'ecommerce.receipt.order.payment.method',
+    defaultMessage: 'Payment Method:',
+    description: 'Order summary heading for payment method',
+  },
+  'ecommerce.receipt.table.column.quantity': {
+    id: 'ecommerce.receipt.table.column.quantity',
+    defaultMessage: 'Quantity',
+    description: 'Column quantity title for order info table',
+  },
+  'ecommerce.receipt.table.column.description': {
+    id: 'ecommerce.receipt.table.column.description',
+    defaultMessage: 'Description',
+    description: 'Column description title for order info table',
+  },
+  'ecommerce.receipt.table.column.price': {
+    id: 'ecommerce.receipt.table.column.price',
+    defaultMessage: 'Item Price',
+    description: 'Column item price title for order info table',
+  },
+  'ecommerce.receipt.loading.order': {
+    id: 'ecommerce.receipt.loading.order',
+    defaultMessage: 'Loading order...',
+    description: 'Message when order is being loaded',
+  },
+  'ecommerce.receipt.link.dashboard': {
+    id: 'ecommerce.receipt.link.dashboard',
+    defaultMessage: 'Go to dashboard',
+    description: 'Link to learner dashboard',
+  },
+  'ecommerce.receipt.link.find.courses': {
+    id: 'ecommerce.receipt.link.find.courses',
+    defaultMessage: 'Find more courses',
+    description: 'Link to search for courses',
+  },
+});
+
+export default messages;

--- a/src/receipt/ReceiptPage.test.jsx
+++ b/src/receipt/ReceiptPage.test.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { createMemoryHistory } from 'history';
+
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import ConnectedReceiptPage from './ReceiptPage';
+
+const mockStore = configureMockStore();
+const initialState = {
+  receipt: {
+    loadingReceipt: false,
+    loadingReceiptError: null,
+    order: {
+    },
+  },
+};
+
+const loadedOrderMock = {
+  // eslint-disable-next-line global-require
+  order: require('./__mocks__/orderLoaded.mockStore'),
+};
+
+const renderWithProviders = children => renderer.create((
+  <IntlProvider locale="en">
+    <Provider store={mockStore(initialState)}>
+      {children}
+    </Provider>
+  </IntlProvider>
+));
+
+describe('<ReceiptPage />', () => {
+  it('renders error view if there is an error loading the order', () => {
+    const mockHistory = createMemoryHistory('/receipt');
+    const store = mockStore({
+      ...initialState,
+      receipt: {
+        ...initialState.receipt,
+        loadingReceiptError: 'Error!',
+      },
+    });
+    const tree = renderWithProviders(<ConnectedReceiptPage history={mockHistory} store={store} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders a receipt page', () => {
+    const mockHistory = createMemoryHistory('/receipt');
+    const store = mockStore({
+      ...initialState,
+      receipt: {
+        ...initialState.receipt,
+        order: loadedOrderMock.order,
+      },
+    });
+    const tree = renderWithProviders(<ConnectedReceiptPage history={mockHistory} store={store} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders discount information', () => {
+    const mockHistory = createMemoryHistory('/receipt');
+    const store = mockStore({
+      ...initialState,
+      receipt: {
+        ...initialState.receipt,
+        order: {
+          ...loadedOrderMock.order,
+          vouchers: [
+            {
+              benefit: {
+                type: 'Percentage',
+                value: 10,
+              },
+              code: '12345',
+              id: 2,
+              redeem_url: 'http://localhost:18130/coupons/offer/?code=12345',
+              total_discount: '14.90',
+            },
+          ],
+        },
+      },
+    });
+    const tree = renderWithProviders(<ConnectedReceiptPage history={mockHistory} store={store} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders credit messaging', () => {
+    const mockHistory = createMemoryHistory('/receipt');
+    const store = mockStore({
+      ...initialState,
+      receipt: {
+        ...initialState.receipt,
+        order: {
+          ...loadedOrderMock.order,
+          contains_credit_seat: true,
+        },
+      },
+    });
+    const tree = renderWithProviders(<ConnectedReceiptPage history={mockHistory} store={store} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders enterprise message banner', () => {
+    const mockHistory = createMemoryHistory('/receipt');
+    const store = mockStore({
+      ...initialState,
+      receipt: {
+        ...initialState.receipt,
+        order: {
+          ...loadedOrderMock.order,
+          enterprise_learner_portal_url: 'http://www.enterprise.com',
+        },
+      },
+    });
+    const tree = renderWithProviders(<ConnectedReceiptPage history={mockHistory} store={store} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/receipt/__mocks__/orderLoaded.mockStore.js
+++ b/src/receipt/__mocks__/orderLoaded.mockStore.js
@@ -1,0 +1,57 @@
+module.exports = {
+    basket_discounts: [
+        {
+            amount: 14.9,
+            benefit_value: 10,
+            code: "12345",
+            condition_name: "Cart includes 1 item(s) from range for coupon [14]",
+            contains_offer: true,
+            currency: "USD",
+            enterprise_customer_name: null,
+            offer_type: "Voucher",
+        }
+    ],
+    billing_address: {
+        city: "Cambridge",
+        country: "US",
+        first_name: "Juliana",
+        last_name: "Doe",
+        line1: "123 Main Street",
+        line2: "",
+        postcode: "12346",
+        state: "CA",
+    },
+    contains_credit_seat: false,
+    currency: "USD",
+    dashboard_url: "http://edx.devstack.lms:18000/dashboard",
+    date_placed: "2022-06-21T16:43:02Z",
+    discount: "14.90",
+    enterprise_learner_portal_url: null,
+    lines: [
+        {
+            course_organization: "edX",
+            description: 'Seat in edX Demonstration Course with verified certificate',
+            line_price_excl_tax: "134.10",
+            product: {
+                id: 3,
+                is_available_to_buy: true,
+                is_enrollment_code_product: false,
+                price: "149.00",
+            },
+            title: "Seat in edX Demonstration Course with verified certificate",
+            unit_price_excl_tax: "149.00",
+        }
+    ],
+    number: "EDX-100005",
+    order_product_ids: "3",
+    payment_method: "Visa 411111XXXXXX1111",
+    product_tracking: null,
+    total_before_discounts_incl_tax: "149.00",
+    total_excl_tax: "134.10",
+    user: {
+        email: "edx@example.com",
+        username: "edx",
+    },
+    vouchers: [],
+};
+  

--- a/src/receipt/__snapshots__/ReceiptPage.test.jsx.snap
+++ b/src/receipt/__snapshots__/ReceiptPage.test.jsx.snap
@@ -1,0 +1,1219 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ReceiptPage /> renders a receipt page 1`] = `
+<div
+  className="page__receipt receipt container content-container"
+  data-currency="USD"
+  data-order-id="EDX-100005"
+  data-product-ids="3"
+  data-total-amount="149.00"
+  id="receipt-container"
+>
+  <div
+    className="list-info"
+  >
+    <h2
+      className="thank-you text-primary-500"
+    >
+      Thank you for your order!
+    </h2>
+    <div
+      className="info-item payment-info row"
+    >
+      <div
+        className="copy col-md-8"
+      >
+        <div
+          className="confirm-message"
+        >
+          <span>
+            Your order is complete. If you need a receipt, you can print this page.
+          </span>
+        </div>
+        <address
+          className="billing-address"
+          data-hj-suppress={true}
+        >
+          Juliana
+           
+          Doe
+          <br />
+          123 Main Street
+          <br />
+          Cambridge
+          <br />
+          CA
+          <br />
+          12346
+          <br />
+          US
+          <br />
+        </address>
+      </div>
+      <div
+        className="order-summary col-md-4"
+      >
+        <dl>
+          <dt>
+            Order Number:
+          </dt>
+          <dd>
+            EDX-100005
+          </dd>
+          <dt>
+            Payment Method:
+          </dt>
+          <dd>
+            Visa 411111XXXXXX1111
+          </dd>
+          <dt>
+            Order Date:
+          </dt>
+          <dd>
+            Jun 21, 2022
+          </dd>
+        </dl>
+      </div>
+    </div>
+    <h2
+      className="text-primary-500"
+    >
+      Order Information
+    </h2>
+    <div
+      className="info-table"
+    >
+      <div
+        className="pgn__data-table-layout-wrapper"
+      >
+        <div
+          className="pgn__data-table-layout-main"
+        >
+          <div
+            className="pgn__data-table-wrapper"
+          >
+            <div
+              className="pgn__data-table-container"
+            >
+              <table
+                className="pgn__data-table is-striped"
+                role="table"
+              >
+                <thead>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Quantity
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Description
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Item Price
+                        </span>
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  role="rowgroup"
+                >
+                  <tr
+                    className="pgn__data-table-row"
+                    role="row"
+                  >
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      
+                    </td>
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      <span
+                        className="course-description-title"
+                      >
+                        Seat in edX Demonstration Course with verified certificate
+                      </span>
+                      <span
+                        className="course-description-subtitle"
+                      />
+                    </td>
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      $149.00
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="order-total col-6 ml-auto"
+      >
+        <div
+          className="order-total-item border-divider pgn__action-row"
+        >
+          <span
+            className="description"
+          >
+            Subtotal
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          $149.00
+        </div>
+        <div
+          className="order-total-item pgn__action-row"
+        >
+          <span
+            className="badge badge-success"
+          >
+            Discount
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span
+            data-hj-suppress={true}
+          >
+            12345
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span>
+            10
+            % off
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span>
+            -$14.90
+          </span>
+        </div>
+        <div
+          className="border-divider pgn__action-row"
+        />
+        <div
+          className="order-total-item pgn__action-row"
+        >
+          <span>
+            Total
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          $134.10
+        </div>
+      </div>
+    </div>
+    <div
+      className="pgn__action-row"
+      id="cta-nav-links"
+    >
+      <a
+        className="pgn__hyperlink default-link standalone-link dashboard-link"
+        href="http://localhost:18000/dashboard"
+        onClick={[Function]}
+        target="_self"
+      >
+        Go to dashboard
+      </a>
+      <a
+        className="pgn__hyperlink default-link standalone-link"
+        href="http://localhost:18000/courses"
+        onClick={[Function]}
+        target="_self"
+      >
+        Find more courses
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ReceiptPage /> renders credit messaging 1`] = `
+<div
+  className="page__receipt receipt container content-container"
+  data-currency="USD"
+  data-order-id="EDX-100005"
+  data-product-ids="3"
+  data-total-amount="149.00"
+  id="receipt-container"
+>
+  <div
+    className="list-info"
+  >
+    <h2
+      className="thank-you text-primary-500"
+    >
+      Thank you for your order!
+    </h2>
+    <div
+      className="info-item payment-info row"
+    >
+      <div
+        className="copy col-md-8"
+      >
+        <div
+          className="confirm-message"
+        >
+          <span>
+            Your order is complete. If you need a receipt, you can print this page.
+          </span>
+        </div>
+        <address
+          className="billing-address"
+          data-hj-suppress={true}
+        >
+          Juliana
+           
+          Doe
+          <br />
+          123 Main Street
+          <br />
+          Cambridge
+          <br />
+          CA
+          <br />
+          12346
+          <br />
+          US
+          <br />
+        </address>
+      </div>
+      <div
+        className="order-summary col-md-4"
+      >
+        <dl>
+          <dt>
+            Order Number:
+          </dt>
+          <dd>
+            EDX-100005
+          </dd>
+          <dt>
+            Payment Method:
+          </dt>
+          <dd>
+            Visa 411111XXXXXX1111
+          </dd>
+          <dt>
+            Order Date:
+          </dt>
+          <dd>
+            Jun 21, 2022
+          </dd>
+        </dl>
+      </div>
+    </div>
+    <h2
+      className="text-primary-500"
+    >
+      Order Information
+    </h2>
+    <div
+      className="info-table"
+    >
+      <div
+        className="pgn__data-table-layout-wrapper"
+      >
+        <div
+          className="pgn__data-table-layout-main"
+        >
+          <div
+            className="pgn__data-table-wrapper"
+          >
+            <div
+              className="pgn__data-table-container"
+            >
+              <table
+                className="pgn__data-table is-striped"
+                role="table"
+              >
+                <thead>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Quantity
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Description
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Item Price
+                        </span>
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  role="rowgroup"
+                >
+                  <tr
+                    className="pgn__data-table-row"
+                    role="row"
+                  >
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      
+                    </td>
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      <span
+                        className="course-description-title"
+                      >
+                        Seat in edX Demonstration Course with verified certificate
+                      </span>
+                      <span
+                        className="course-description-subtitle"
+                      />
+                    </td>
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      $149.00
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="order-total col-6 ml-auto"
+      >
+        <div
+          className="order-total-item border-divider pgn__action-row"
+        >
+          <span
+            className="description"
+          >
+            Subtotal
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          $149.00
+        </div>
+        <div
+          className="order-total-item pgn__action-row"
+        >
+          <span
+            className="badge badge-success"
+          >
+            Discount
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span
+            data-hj-suppress={true}
+          >
+            12345
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span>
+            10
+            % off
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span>
+            -$14.90
+          </span>
+        </div>
+        <div
+          className="border-divider pgn__action-row"
+        />
+        <div
+          className="order-total-item pgn__action-row"
+        >
+          <span>
+            Total
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          $134.10
+        </div>
+      </div>
+    </div>
+    <div
+      className="fade alert-content credit-messaging alert alert-warning show"
+      role="alert"
+    >
+      <span
+        className="pgn__icon alert-icon"
+      >
+        <svg
+          aria-hidden={true}
+          fill="none"
+          focusable={false}
+          height={24}
+          role="img"
+          viewBox="0 0 24 24"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+      <div
+        className="pgn__alert-message-wrapper"
+      >
+        <div
+          className="alert-message-content"
+        >
+          <div
+            className="alert-heading h4"
+          >
+            Get Your Course Credit
+          </div>
+          <p>
+            To receive academic credit for this course, you must apply for credit at the organization that offers the credit. You can find a link to the organization’s website on your 
+            <a
+              className="inline-link-underline"
+              href="http://localhost:18000/dashboard"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              dashboard
+            </a>
+            , next to the course name.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pgn__action-row"
+      id="cta-nav-links"
+    >
+      <a
+        className="pgn__hyperlink default-link standalone-link dashboard-link"
+        href="http://localhost:18000/dashboard"
+        onClick={[Function]}
+        target="_self"
+      >
+        Go to dashboard
+      </a>
+      <a
+        className="pgn__hyperlink default-link standalone-link"
+        href="http://localhost:18000/courses"
+        onClick={[Function]}
+        target="_self"
+      >
+        Find more courses
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ReceiptPage /> renders discount information 1`] = `
+<div
+  className="page__receipt receipt container content-container"
+  data-currency="USD"
+  data-order-id="EDX-100005"
+  data-product-ids="3"
+  data-total-amount="149.00"
+  id="receipt-container"
+>
+  <div
+    className="list-info"
+  >
+    <h2
+      className="thank-you text-primary-500"
+    >
+      Thank you for your order!
+    </h2>
+    <div
+      className="info-item payment-info row"
+    >
+      <div
+        className="copy col-md-8"
+      >
+        <div
+          className="confirm-message"
+        >
+          <span>
+            Your order is complete. If you need a receipt, you can print this page.
+          </span>
+        </div>
+        <address
+          className="billing-address"
+          data-hj-suppress={true}
+        >
+          Juliana
+           
+          Doe
+          <br />
+          123 Main Street
+          <br />
+          Cambridge
+          <br />
+          CA
+          <br />
+          12346
+          <br />
+          US
+          <br />
+        </address>
+      </div>
+      <div
+        className="order-summary col-md-4"
+      >
+        <dl>
+          <dt>
+            Order Number:
+          </dt>
+          <dd>
+            EDX-100005
+          </dd>
+          <dt>
+            Payment Method:
+          </dt>
+          <dd>
+            Visa 411111XXXXXX1111
+          </dd>
+          <dt>
+            Order Date:
+          </dt>
+          <dd>
+            Jun 21, 2022
+          </dd>
+        </dl>
+      </div>
+    </div>
+    <h2
+      className="text-primary-500"
+    >
+      Order Information
+    </h2>
+    <div
+      className="info-table"
+    >
+      <div
+        className="pgn__data-table-layout-wrapper"
+      >
+        <div
+          className="pgn__data-table-layout-main"
+        >
+          <div
+            className="pgn__data-table-wrapper"
+          >
+            <div
+              className="pgn__data-table-container"
+            >
+              <table
+                className="pgn__data-table is-striped"
+                role="table"
+              >
+                <thead>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Quantity
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Description
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Item Price
+                        </span>
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  role="rowgroup"
+                >
+                  <tr
+                    className="pgn__data-table-row"
+                    role="row"
+                  >
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      
+                    </td>
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      <span
+                        className="course-description-title"
+                      >
+                        Seat in edX Demonstration Course with verified certificate
+                      </span>
+                      <span
+                        className="course-description-subtitle"
+                      />
+                    </td>
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      $149.00
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="order-total col-6 ml-auto"
+      >
+        <div
+          className="order-total-item border-divider pgn__action-row"
+        >
+          <span
+            className="description"
+          >
+            Subtotal
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          $149.00
+        </div>
+        <div
+          className="order-total-item pgn__action-row"
+        >
+          <span
+            className="badge badge-success"
+          >
+            Discount
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span
+            data-hj-suppress={true}
+          >
+            12345
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span>
+            10
+            % off
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span>
+            -$14.90
+          </span>
+        </div>
+        <div
+          className="border-divider pgn__action-row"
+        />
+        <div
+          className="order-total-item pgn__action-row"
+        >
+          <span>
+            Total
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          $134.10
+        </div>
+      </div>
+    </div>
+    <div
+      className="pgn__action-row"
+      id="cta-nav-links"
+    >
+      <a
+        className="pgn__hyperlink default-link standalone-link dashboard-link"
+        href="http://localhost:18000/dashboard"
+        onClick={[Function]}
+        target="_self"
+      >
+        Go to dashboard
+      </a>
+      <a
+        className="pgn__hyperlink default-link standalone-link"
+        href="http://localhost:18000/courses"
+        onClick={[Function]}
+        target="_self"
+      >
+        Find more courses
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ReceiptPage /> renders enterprise message banner 1`] = `
+<div
+  className="page__receipt receipt container content-container"
+  data-currency="USD"
+  data-order-id="EDX-100005"
+  data-product-ids="3"
+  data-total-amount="149.00"
+  id="receipt-container"
+>
+  <div
+    className="enterprise-message"
+  >
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className="pgn__pageBanner-component pgn__pageBanner__accentA"
+      role="alert"
+    >
+      <div
+        className="pgn__pageBanner-content"
+      >
+        Your company, , has a dedicated page where you can see all of your sponsored courses. Go to 
+        <a
+          className="inline-link-underline"
+          href="http://www.enterprise.com"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          your learner portal
+        </a>
+        .
+      </div>
+      <span
+        className="pgn__pageBanner-dismissButtonContainer"
+      >
+        <button
+          aria-label="Dismiss"
+          className="btn-icon btn-icon-black btn-icon-inline"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            className="btn-icon__icon-container"
+          >
+            <span
+              className="pgn__icon btn-icon__icon"
+              icon={Object {}}
+            >
+              <svg
+                aria-hidden={true}
+                fill="none"
+                focusable={false}
+                height={24}
+                role="img"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="list-info"
+  >
+    <h2
+      className="thank-you text-primary-500"
+    >
+      Thank you for your order!
+    </h2>
+    <div
+      className="info-item payment-info row"
+    >
+      <div
+        className="copy col-md-8"
+      >
+        <div
+          className="confirm-message"
+        >
+          <span>
+            Your order is complete. If you need a receipt, you can print this page.
+          </span>
+        </div>
+        <address
+          className="billing-address"
+          data-hj-suppress={true}
+        >
+          Juliana
+           
+          Doe
+          <br />
+          123 Main Street
+          <br />
+          Cambridge
+          <br />
+          CA
+          <br />
+          12346
+          <br />
+          US
+          <br />
+        </address>
+      </div>
+      <div
+        className="order-summary col-md-4"
+      >
+        <dl>
+          <dt>
+            Order Number:
+          </dt>
+          <dd>
+            EDX-100005
+          </dd>
+          <dt>
+            Payment Method:
+          </dt>
+          <dd>
+            Visa 411111XXXXXX1111
+          </dd>
+          <dt>
+            Order Date:
+          </dt>
+          <dd>
+            Jun 21, 2022
+          </dd>
+        </dl>
+      </div>
+    </div>
+    <h2
+      className="text-primary-500"
+    >
+      Order Information
+    </h2>
+    <div
+      className="info-table"
+    >
+      <div
+        className="pgn__data-table-layout-wrapper"
+      >
+        <div
+          className="pgn__data-table-layout-main"
+        >
+          <div
+            className="pgn__data-table-wrapper"
+          >
+            <div
+              className="pgn__data-table-container"
+            >
+              <table
+                className="pgn__data-table is-striped"
+                role="table"
+              >
+                <thead>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Quantity
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Description
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      colSpan={1}
+                      role="columnheader"
+                    >
+                      <span
+                        className="d-flex align-items-center"
+                      >
+                        <span>
+                          Item Price
+                        </span>
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  role="rowgroup"
+                >
+                  <tr
+                    className="pgn__data-table-row"
+                    role="row"
+                  >
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      
+                    </td>
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      <span
+                        className="course-description-title"
+                      >
+                        Seat in edX Demonstration Course with verified certificate
+                      </span>
+                      <span
+                        className="course-description-subtitle"
+                      />
+                    </td>
+                    <td
+                      className="pgn__data-table-cell-wrap"
+                      role="cell"
+                    >
+                      $149.00
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="order-total col-6 ml-auto"
+      >
+        <div
+          className="order-total-item border-divider pgn__action-row"
+        >
+          <span
+            className="description"
+          >
+            Subtotal
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          $149.00
+        </div>
+        <div
+          className="order-total-item pgn__action-row"
+        >
+          <span
+            className="badge badge-success"
+          >
+            Discount
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span
+            data-hj-suppress={true}
+          >
+            12345
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span>
+            10
+            % off
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          <span>
+            -$14.90
+          </span>
+        </div>
+        <div
+          className="enterprise-customer"
+        >
+          Courtesy of  is provided
+        </div>
+        <div
+          className="border-divider pgn__action-row"
+        />
+        <div
+          className="order-total-item pgn__action-row"
+        >
+          <span>
+            Total
+          </span>
+          <span
+            className="pgn__action-row-spacer"
+          />
+          $134.10
+        </div>
+      </div>
+    </div>
+    <div
+      className="pgn__action-row"
+      id="cta-nav-links"
+    >
+      <a
+        className="pgn__hyperlink default-link standalone-link dashboard-link"
+        href="http://localhost:18000/dashboard"
+        onClick={[Function]}
+        target="_self"
+      >
+        Go to dashboard
+      </a>
+      <a
+        className="pgn__hyperlink default-link standalone-link"
+        href="http://localhost:18000/courses"
+        onClick={[Function]}
+        target="_self"
+      >
+        Find more courses
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ReceiptPage /> renders error view if there is an error loading the order 1`] = `
+<div
+  className="page__receipt receipt container content-container pt-5 pb-5"
+  id="receipt-container"
+>
+  <span>
+    The specified order could not be located. Please ensure that the URL is correct, and try again. You may also view your previous orders on the 
+    <a
+      className="inline-link-underline"
+      href="https://localhost:1996/orders"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      order history
+    </a>
+     page.
+  </span>
+</div>
+`;

--- a/src/receipt/_style.scss
+++ b/src/receipt/_style.scss
@@ -1,0 +1,63 @@
+#receipt-container {
+    width: 1170px;
+    padding-top: 2rem;
+}
+
+.page__receipt {
+    h2 {
+        margin-bottom: 10px;
+        font-weight: 400;
+    }
+
+    .thank-you {
+        font-size: 38px;
+    }
+
+    .info-item {
+        overflow: hidden;
+    }
+
+    .copy {
+        > div {
+            margin-bottom: 1rem;
+            line-height: 1.5rem;
+        }
+
+        .billing-address {
+            margin: 2rem 0;
+        }
+    }
+
+    .credit-messaging{
+        margin-top: 2rem;
+    }
+
+    .order-total {
+        font-size: 0.875rem;
+        margin-top: 3rem;
+
+        .order-total-item {
+            padding: 1rem;
+            font-weight: bold;
+        }
+
+        .border-divider {
+            border-bottom: 1px solid $gray-200;
+        }
+
+        .enterprise-customer {
+            padding-bottom: 12px;
+            color: $gray-300;
+            text-align: center;
+        }
+    }
+
+    #cta-nav-links {
+        margin: 2rem 0 4rem 0;
+
+        .dashboard-link {
+            margin-right: 2.5rem;
+        }
+    }
+
+}

--- a/src/receipt/_style.scss
+++ b/src/receipt/_style.scss
@@ -28,8 +28,12 @@
         }
     }
 
-    .credit-messaging{
+    .credit-messaging {
         margin-top: 2rem;
+    }
+
+    .enterprise-message {
+        margin-bottom: 2rem;
     }
 
     .order-total {

--- a/src/receipt/actions.js
+++ b/src/receipt/actions.js
@@ -1,0 +1,25 @@
+import { utils } from '../common';
+
+const { AsyncActionType } = utils;
+
+export const FETCH_ORDER = new AsyncActionType('RECEIPT', 'FETCH_ORDER');
+
+// FETCH ORDER ACTIONS
+
+export const fetchOrder = (orderToFetch) => ({
+  type: FETCH_ORDER.BASE,
+  payload: { orderToFetch },
+});
+
+export const fetchOrderBegin = () => ({
+  type: FETCH_ORDER.BEGIN,
+});
+
+export const fetchOrderSuccess = result => ({
+  type: FETCH_ORDER.SUCCESS,
+  payload: result,
+});
+
+export const fetchOrderReset = () => ({
+  type: FETCH_ORDER.RESET,
+});

--- a/src/receipt/actions.js
+++ b/src/receipt/actions.js
@@ -20,6 +20,11 @@ export const fetchOrderSuccess = result => ({
   payload: result,
 });
 
+export const fetchOrderFailure = error => ({
+  type: FETCH_ORDER.FAILURE,
+  payload: { error },
+});
+
 export const fetchOrderReset = () => ({
   type: FETCH_ORDER.RESET,
 });

--- a/src/receipt/index.js
+++ b/src/receipt/index.js
@@ -1,0 +1,11 @@
+import ConnectedReceiptPage from './ReceiptPage';
+import reducer from './reducer';
+import saga from './saga';
+import { storeName } from './selectors';
+
+export {
+  ConnectedReceiptPage,
+  saga,
+  reducer,
+  storeName,
+};

--- a/src/receipt/reducer.js
+++ b/src/receipt/reducer.js
@@ -1,0 +1,34 @@
+import { FETCH_ORDER } from './actions';
+
+export const initialState = {
+  loadingReceipt: false,
+  loadingReceiptError: null,
+  order: null,
+};
+
+const receiptPage = (state = initialState, action) => { // eslint-disable-line default-param-last
+  switch (action.type) {
+    case FETCH_ORDER.BEGIN:
+      return {
+        ...state,
+        loadingReceiptError: null,
+        loadingReceipt: true,
+      };
+    case FETCH_ORDER.SUCCESS:
+      return {
+        ...state,
+        order: action.payload.order,
+        loadingReceipt: false,
+      };
+    case FETCH_ORDER.RESET:
+      return {
+        ...state,
+        loadingReceiptError: null,
+        loadingReceipt: false,
+      };
+    default:
+      return state;
+  }
+};
+
+export default receiptPage;

--- a/src/receipt/reducer.js
+++ b/src/receipt/reducer.js
@@ -20,6 +20,12 @@ const receiptPage = (state = initialState, action) => { // eslint-disable-line d
         order: action.payload.order,
         loadingReceipt: false,
       };
+    case FETCH_ORDER.FAILURE:
+      return {
+        ...state,
+        loadingReceiptError: action.payload.error,
+        loadingReceipt: false,
+      };
     case FETCH_ORDER.RESET:
       return {
         ...state,

--- a/src/receipt/saga.js
+++ b/src/receipt/saga.js
@@ -1,0 +1,29 @@
+import { call, put, takeEvery } from 'redux-saga/effects';
+
+// Actions
+import {
+  FETCH_ORDER,
+  fetchOrderBegin,
+  fetchOrderSuccess,
+  fetchOrderReset,
+} from './actions';
+
+// Services
+import * as OrderApiService from './service';
+
+export function* handleFetchOrder(action) {
+  console.log('[Saga] 1.a) action', action);
+  const { orderToFetch } = action.payload;
+  // JK TODO: try and finally block? Remove console.log
+  console.log('[Saga] 1.b) orderToFetch:', orderToFetch);
+  yield put(fetchOrderBegin());
+  const result = yield call(OrderApiService.getOrder, orderToFetch);
+  console.log('[Saga] 1.c) result:', result);
+  yield put(fetchOrderSuccess(result));
+  console.log('[Saga] 1.d) success');
+  yield put(fetchOrderReset());
+}
+
+export default function* receiptSaga() {
+  yield takeEvery(FETCH_ORDER.BASE, handleFetchOrder);
+}

--- a/src/receipt/selectors.js
+++ b/src/receipt/selectors.js
@@ -1,0 +1,5 @@
+export const storeName = 'receipt';
+
+export const receiptSelector = state => ({
+  ...state[storeName],
+});

--- a/src/receipt/service.js
+++ b/src/receipt/service.js
@@ -1,0 +1,16 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform';
+
+const { ECOMMERCE_BASE_URL } = getConfig();
+
+const ECOMMERCE_API_BASE_URL = `${ECOMMERCE_BASE_URL}/api/v2`;
+
+// eslint-disable-next-line import/prefer-default-export
+export async function getOrder(orderNumber) {
+  const httpClient = getAuthenticatedHttpClient();
+
+  const { data } = await httpClient.get(`${ECOMMERCE_API_BASE_URL}/orders/${orderNumber}`);
+  return {
+    order: data,
+  };
+}

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -3,9 +3,13 @@ import {
   reducer as orderHistoryReducer,
   storeName as orderHistoryStoreName,
 } from './order-history';
+import {
+  reducer as receiptReducer,
+} from './receipt';
 
 const createRootReducer = () => combineReducers({
   [orderHistoryStoreName]: orderHistoryReducer,
+  receipt: receiptReducer,
 });
 
 export default createRootReducer;

--- a/src/sagas.js
+++ b/src/sagas.js
@@ -1,8 +1,10 @@
 import { all } from 'redux-saga/effects';
 import { saga as orderHistorySaga } from './order-history';
+import { saga as receiptSaga } from './receipt';
 
 export default function* rootSaga() {
   yield all([
     orderHistorySaga(),
+    receiptSaga(),
   ]);
 }


### PR DESCRIPTION
[REV-2683](https://2u-internal.atlassian.net/browse/REV-2683).
We're moving the Receipt Page from ecommerce repo to this MFE for the [Theseus Project](https://2u-internal.atlassian.net/wiki/spaces/RS/pages/7963455/Theseus+Project).
Current receipt page template: https://github.com/edx/ecommerce/blob/947c9068928281d24a54a86ea6df3340309a4f57/ecommerce/templates/edx/checkout/receipt.html#L1
Related backend PRs: 
https://github.com/openedx/ecommerce/pull/3748
https://github.com/openedx/ecommerce/pull/3778
https://github.com/openedx/ecommerce/pull/3781

**Note:** for screenshots of all the different versions, pls refer to https://2u-internal.atlassian.net/l/cp/N8fuc5Py

**Receipt page before:**
![ReceiptPage_OLD_basic](https://user-images.githubusercontent.com/13632680/181372753-04c2573f-4ee2-472d-b54a-5948249ade19.png)


**Receipt page after:**
![ReceiptPage_basic](https://user-images.githubusercontent.com/13632680/181307890-da643d11-8bff-4e9b-9616-a1c9797fae44.png)


_Order History update tag-along:_
This is not part of this ticket, but Paragon's `Table` component will be deprecated, I'm updating the Order History page to use `DataTable` so that both Order History and Receipt Page have the same look for tables.
<img width="1278" alt="Screen Shot 2022-06-07 at 3 43 08 PM" src="https://user-images.githubusercontent.com/13632680/173113903-526c0686-4c70-4b79-ad90-260f793a1470.png">

<img width="1278" alt="Screen Shot 2022-06-07 at 3 42 35 PM" src="https://user-images.githubusercontent.com/13632680/173113917-dc22c580-cbca-4c83-bde4-394eb1f79e84.png">

**This PR:**
- Creates the receipt page 
- Updates Order History to use the new `DataTable` Paragon component
- Adds unit/snapshot tests

This PR is dependent on the backend work in https://2u-internal.atlassian.net/browse/REV-2788

**To test locally:**
1) Enroll in a course, upgrade and make a purchase
2) Go to http://localhost:1996/orders to make sure you have orders 
3) Choose an order number (ie. EDX-100005) and go to `http://localhost:1996/receipt/?order_number={order-number}`
4) To see a discount, a coupon must be created here http://localhost:18130/coupons/ and applied at checkout
5) This page CANNOT be accessed yet through the "View Order Details" link on Order History, this contains our current ecommerce receipt page