### PR TITLE
Update codecov uploader in CI

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -48,4 +48,4 @@ jobs:
       run: npm run is-es5
 
     - name: Run Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
This PR move the codecov in CI to the latest version in order to keep it consistent with frontend repos being updated to v3