### PR TITLE
Paragon table deprecation migration to DataTable

### DIFF
--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -94,6 +94,7 @@ class OrderHistoryPage extends React.Component {
       <DataTable
         className="order-history table-bordered"
         data={this.getTableData()}
+        itemCount={this.props.orders.length}
         columns={[
           {
             Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.items']),

--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -10,7 +10,7 @@ import {
   FormattedDate,
   FormattedNumber,
 } from '@edx/frontend-platform/i18n';
-import { Table, Hyperlink, Pagination } from '@edx/paragon';
+import { DataTable, Hyperlink, Pagination } from '@edx/paragon';
 import MediaQuery from 'react-responsive';
 
 import messages from './OrderHistoryPage.messages';
@@ -91,29 +91,29 @@ class OrderHistoryPage extends React.Component {
 
   renderOrdersTable() {
     return (
-      <Table
+      <DataTable
         className="order-history table-bordered"
         data={this.getTableData()}
         columns={[
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.items']),
-            key: 'description',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.items']),
+            accessor: 'description',
           },
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.date.placed']),
-            key: 'datePlaced',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.date.placed']),
+            accessor: 'datePlaced',
           },
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.total.cost']),
-            key: 'total',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.total.cost']),
+            accessor: 'total',
           },
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.number']),
-            key: 'orderId',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.number']),
+            accessor: 'orderId',
           },
           {
-            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.details']),
-            key: 'receiptUrl',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.details']),
+            accessor: 'receiptUrl',
           },
         ]}
       />


### PR DESCRIPTION
### Ticket
[Migrate off deprecated Paragon components](https://github.com/openedx/frontend-wg/issues/102)

### What has changed
Removed deprecated `Table` component of paragon and updated it with `DataTable`

### References
[Paragon Table](https://paragon-openedx.netlify.app/components/table/)
[Paragon DataTable](https://paragon-openedx.netlify.app/components/datatable/)
