### PR TITLE
Fix [RTL]: align order item quantity multiplier with text direction

### DIFF
--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -83,7 +83,7 @@ class OrderHistoryPage extends React.Component {
       quantity,
     }) => (
       <p className="d-flex" key={description}>
-        <span className="mr-3">{quantity}x</span>
+        <span className="mr-3">{quantity}&times;</span>
         <span>{description}</span>
       </p>
     ));


### PR DESCRIPTION
**TL;DR -** Fixes writing direction for the quantity multiplier (x operator) in the order history table.

## Description
- When multiplication is written using an attached 'x' character, the number and x are treated as a single LTR word, thus not following the proper direction for RTL languages.
- The fix consists of replacing 'x' character with the '&times;' operator (treated as punctuation)

**Rejected fix candidates:**
- **Add a space before the 'x':** works but the added space causes quantity and 'x' to be on 2 separate lines when in small screen.
- **Use a spaceless character 'RLM' to fix direction only for RTL:** it works but needs to add another condition to apply the fix only for RTL language, which implies more code (+1 import), which is not as clean as replacing only a single character.

## Testing instructions
- On your Open edX instance, select an RTL language (e.g. Arabic).
- Go to order history.
- You should have something purchased to see the table contents.

## Screenshots
|  | LTR | RTL |
| --- | --- | --- |
| Original | ![original-ltr](https://user-images.githubusercontent.com/10594967/195636079-e766c179-baec-4134-8b10-dead5befe956.png) | ![original-rtl](https://user-images.githubusercontent.com/10594967/195636337-0f59f933-2780-4573-a28a-f7cc56af9fb8.png) |
| Rejected (w/ space) | ![rejected-ltr](https://user-images.githubusercontent.com/10594967/195636160-1db8ff86-3da8-4e3f-9071-ece811d6bf10.png) | ![rejected-rtl](https://user-images.githubusercontent.com/10594967/195636376-e92f3925-de08-4a3c-ad3f-ba2066c6bee6.png) |
| Fixed (with &times; operator) | ![fixed-ltr](https://user-images.githubusercontent.com/10594967/195636278-985842f7-a9ed-4a8c-8ffb-d3857116b029.png) | ![fixed-rtl](https://user-images.githubusercontent.com/10594967/195636309-1883b8e7-5e8d-4801-a444-fb50da79ac7b.png) |

