### PR TITLE
build: [REV-1551] update renovate.json to match f-a-payment

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,14 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "group:allNonMajor",
+    ":automergePatch",
+    ":label(dependencies)",
+    ":rebaseStalePrs",
+    ":reviewer(edx-revenue-tasks)",
+    ":semanticCommits",
+    ":timezone(America/New_York)"
   ],
-  "patch": {
-    "automerge": true
-  },
-  "rebaseStalePrs": true,
   "packageRules": [
     {
       "matchPackagePatterns": ["@edx"],


### PR DESCRIPTION
## Description

We are currently experimenting with changing our Renovate configuration.

Mirror Renovate changes to frontend-app-payment to frontend-app-ecommerce.

## Supporting information

* Jira: [REV-1551](https://2u-internal.atlassian.net/browse/REV-1551) Configure Renovate in frontend-app-payment and frontend-app-ecom for dependency updates
* Research: [Confluence](https://2u-internal.atlassian.net/wiki/spaces/~931919476/pages/28246096/REV-1551)

## Testing instructions

Check Renovate is working after merge.