### PR TITLE
fix: Internationalization of ErrorPage when no cookies

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,9 @@ import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Route, Routes } from 'react-router-dom';
-import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { getLocale, IntlProvider } from '@edx/frontend-platform/i18n';
+import { configure as configureI18n } from '@edx/frontend-platform/i18n/lib';
+import { getLoggingService } from '@edx/frontend-platform/logging';
 import { AppProvider, ErrorPage } from '@edx/frontend-platform/react';
 import {
   APP_INIT_ERROR,
@@ -70,6 +72,15 @@ subscribe(APP_READY, () => {
 });
 
 subscribe(APP_INIT_ERROR, (error) => {
+  try {
+    getLocale('en');
+  } catch (e) {
+    configureI18n({
+      messages: {},
+      config: getConfig(),
+      loggingService: getLoggingService(),
+    });
+  }
   ReactDOM.render(
     <IntlProvider locale="en">
       <ErrorPage message={error.message} />


### PR DESCRIPTION
[REV-3700](https://2u-internal.atlassian.net/browse/REV-3700).

There is an issue locally where it errors out with the message `getLocale called before configuring i18n. Call configure with messages first.` since it cannot find a valid locale if the cookies are not set. This fix was done on Payment MFE.