### PR TITLE
fix: Only show subscriptions section if user has any subscriptions

### DIFF
--- a/src/subscriptions/saga.js
+++ b/src/subscriptions/saga.js
@@ -9,6 +9,9 @@ function* handleFetchSubscriptions() {
   try {
     yield put(fetchSubscriptions.request());
     const result = yield call(getSubscriptions);
+    if (!result?.length) {
+      yield put(hideSubscriptionSection());
+    }
     yield put(fetchSubscriptions.success(result));
   } catch (error) {
     /**


### PR DESCRIPTION
[REV-3690](https://2u-internal.atlassian.net/browse/REV-3690).

If a learner does not have any subscriptions (active or inactive), they should only get to see their Order History section and not a subscription section.