### PR TITLE
fix: update frontend-platform version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
         "@edx/frontend-component-footer": "^12.2.1",
         "@edx/frontend-component-header": "^4.6.0",
-        "@edx/frontend-platform": "^5.1.0",
+        "@edx/frontend-platform": "^5.5.1",
         "@edx/paragon": "^20.32.0",
         "@fortawesome/fontawesome-svg-core": "6.1.2",
         "@fortawesome/free-brands-svg-icons": "6.1.2",
@@ -2213,9 +2213,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.1.0.tgz",
-      "integrity": "sha512-/8Njj9015/1zf1Gn896JKhlcc2FIU/sbh0qkcckl74PtXS/p9GB29gTQJbhY7fCA/1grGNJurZvEaqkSU4ze8Q==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.6.1.tgz",
+      "integrity": "sha512-7MOIjGGYplVY7yHrSea90EkQ24UxKxRKU9FaihB41yUSL/Vin1txDuIn3059Xr+60QfIKRsym+LogXe9IZ47Dw==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
         "@formatjs/intl-pluralrules": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
     "@edx/frontend-component-footer": "^12.2.1",
     "@edx/frontend-component-header": "^4.6.0",
-    "@edx/frontend-platform": "^5.1.0",
+    "@edx/frontend-platform": "^5.5.1",
     "@edx/paragon": "^20.32.0",
     "@fortawesome/fontawesome-svg-core": "6.1.2",
     "@fortawesome/free-brands-svg-icons": "6.1.2",


### PR DESCRIPTION
Update the frontend-platform version to fix issues with react-router v6 for instances where the PUBLIC_PATH is used for MFEs instead of the separate domains for each MFE.

The minimum satisfying version of the frontend-platform is v5.5.1 https://github.com/openedx/frontend-platform/releases/tag/v5.5.1

The same fix is already applied to the master:
https://github.com/openedx/frontend-app-ecommerce/pull/340/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

I tested on domain-based (devstack) and PUBLIC_PATH-based (our Dev) instances.

