### PR TITLE
fix: DataTable cells vertical alignment

### DIFF
--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -77,7 +77,7 @@ class OrderHistoryPage extends React.Component {
       description,
       quantity,
     }) => (
-      <p className="d-flex" key={description}>
+      <p className="d-flex m-0" key={description}>
         <span className="mr-3">{quantity}&times;</span>
         <span>{description}</span>
       </p>


### PR DESCRIPTION
This is backport form master - https://github.com/openedx/frontend-app-ecommerce/pull/375

## Description

Our proposal is to remove the bottom margin from the <p> element in the first column of the table. This margin is causing the center alignment within the cell to break in our table. Attached below is a screenshot of the problem and a screenshot after the fix.
<img width="1796" alt="Снимок экрана 2024-03-12 в 00 11 22" src="https://github.com/openedx/frontend-app-ecommerce/assets/19806032/a223169a-7393-4bae-8357-4c5b7ab2254b">

After fix

<img width="1796" alt="Снимок экрана 2024-03-12 в 00 13 14" src="https://github.com/openedx/frontend-app-ecommerce/assets/19806032/dd85b6d7-8028-4152-9cad-ce92ade4b59e">
