### PR TITLE
build: Update codecov and use token

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -40,5 +40,8 @@ jobs:
     - name: Build
       run: npm run build
 
-    - name: Run Coverage
-      uses: codecov/codecov-action@v2
+    - name: Run Code Coverage
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true


### PR DESCRIPTION
Update codecov to the latest version and start using the org-wide token for uploads.

See https://github.com/openedx/wg-frontend/issues/179
